### PR TITLE
Use co_await on request handlers

### DIFF
--- a/cli/cli.cpp
+++ b/cli/cli.cpp
@@ -1,29 +1,89 @@
 #include <httpmicroservice/service.hpp>
 #include <httpmicroservice.hpp>
 
+#include <boost/asio/thread_pool.hpp>
+
 #include <exception>
 #include <iostream>
+#include <thread>
 
 namespace asio = boost::asio;
 namespace usrv = httpmicroservice;
 namespace http = httpmicroservice::http;
 
-usrv::response handler(usrv::request req)
+asio::awaitable<usrv::response> handler_api(usrv::request req)
+{
+    usrv::response res(http::status::ok, req.version());
+    res.set(http::field::content_type, "application/json");
+    res.body() = "{\"hello\": \"api\"}";
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    co_return res;
+}
+
+asio::awaitable<usrv::response> handler(usrv::request req)
 {
     usrv::response res(http::status::ok, req.version());
     res.set(http::field::content_type, "application/json");
     res.body() = "{\"hello\": \"world\"}";
 
-    return res;
+    co_return res;
 }
+
+struct functor {
+    using executor_type = asio::thread_pool::executor_type;
+
+    explicit functor(executor_type ex) : ex_(ex)
+    {
+        std::cout << "functor {\n";
+    }
+
+    ~functor()
+    {
+        std::cout << "} ~functor\n";
+    }
+
+    functor(const functor &other) : ex_(other.ex_)
+    {
+        std::cout << "functor(other) {\n";
+    }
+
+    functor &operator=(const functor &other)
+    {
+        std::cout << "functor = other {\n";
+        ex_ = other.ex_;
+        return *this;
+    }
+
+    asio::awaitable<usrv::response> operator()(usrv::request req)
+    {
+        if (req.target().starts_with("/api")) {
+            auto res = co_await co_spawn(
+                ex_, handler_api(std::move(req)), asio::use_awaitable);
+
+            co_return res;
+        } else {
+            auto res = co_await handler(std::move(req));
+
+            co_return res;
+        }
+    }
+
+    executor_type ex_;
+};
 
 int main()
 {
     try {
         auto port = usrv::getenv_port();
 
+        asio::thread_pool pool(1);
+
         asio::io_context ctx;
-        usrv::async_run(ctx.get_executor(), port, handler);
+        usrv::async_run(
+            ctx.get_executor(), port,
+            usrv::make_handler(pool.get_executor(), handler));
 
         ctx.run();
 

--- a/include/httpmicroservice/service.hpp
+++ b/include/httpmicroservice/service.hpp
@@ -4,6 +4,7 @@
 
 #include <boost/asio/awaitable.hpp>
 #include <boost/asio/co_spawn.hpp>
+#include <boost/asio/detached.hpp>
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/use_awaitable.hpp>
@@ -16,7 +17,7 @@ namespace httpmicroservice {
 namespace asio = boost::asio;
 
 template <typename Acceptor, typename Handler>
-asio::awaitable<void> accept(Acceptor acceptor, Handler handler)
+asio::awaitable<void> accept(Acceptor acceptor, Handler &&handler)
 {
     for (;;) {
         boost::system::error_code ec;
@@ -28,27 +29,30 @@ asio::awaitable<void> accept(Acceptor acceptor, Handler handler)
             break;
         }
 
+        // Bind the handler by value into the session coroutine
+        Handler session_handler(handler);
+
         // Run coroutine to handle one http connection
         co_spawn(
             acceptor.get_executor(),
             session(
-                std::move(stream), handler,
+                std::move(stream), std::move(session_handler),
                 std::make_optional<session_stats>()),
             [](auto ptr, auto stats) {
-                // Propagate exception from the coroutine
                 if (ptr) {
                     std::rethrow_exception(ptr);
                 }
 
                 if (stats) {
-                    std::cout << to_string(*stats) << "\n";
+                    // Use std::endl to flush the stream
+                    std::cout << *stats << std::endl;
                 }
             });
     }
 }
 
 template <typename Handler>
-asio::awaitable<void> listen(int port, Handler handler)
+asio::awaitable<void> listen(int port, Handler &&handler)
 {
     using tcp = asio::ip::tcp;
 
@@ -56,19 +60,29 @@ asio::awaitable<void> listen(int port, Handler handler)
 
     tcp::acceptor acceptor(co_await asio::this_coro::executor, endpoint);
 
-    co_await accept(std::move(acceptor), std::move(handler));
+    co_await accept(std::move(acceptor), std::forward<Handler>(handler));
 }
 
 template <typename Executor, typename Handler>
-void async_run(Executor ex, int port, Handler handler)
+void async_run(Executor ex, int port, Handler &&handler)
 {
     // Run coroutine to listen on our port
-    co_spawn(ex, listen(port, std::move(handler)), [](auto ptr) {
+    co_spawn(ex, listen(port, std::forward<Handler>(handler)), [](auto ptr) {
         // Propagate exception from the coroutine
         if (ptr) {
             std::rethrow_exception(ptr);
         }
     });
+}
+
+template <typename Executor, typename Handler>
+auto make_handler(Executor ex, Handler handler)
+{
+    return [ex, handler](request req) -> asio::awaitable<response> {
+        auto res =
+            co_await co_spawn(ex, handler(std::move(req)), asio::use_awaitable);
+        co_return res;
+    };
 }
 
 } // namespace httpmicroservice

--- a/include/httpmicroservice/types.hpp
+++ b/include/httpmicroservice/types.hpp
@@ -8,6 +8,8 @@
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/http/string_body.hpp>
 
+#include <chrono>
+#include <iosfwd>
 #include <string>
 
 namespace httpmicroservice {
@@ -23,8 +25,10 @@ struct session_stats {
     int num_request = 0;
     int bytes_read = 0;
     int bytes_write = 0;
-    float duration = 0;
+    std::chrono::steady_clock::duration duration;
 };
+
+std::ostream &operator<<(std::ostream &os, const session_stats &stats);
 
 std::string to_string(const session_stats &stats);
 

--- a/src/httpmicroservice.cpp
+++ b/src/httpmicroservice.cpp
@@ -18,8 +18,8 @@ std::ostream &operator<<(std::ostream &os, const session_stats &stats)
 {
     os << "{\"fd\": " << stats.fd << "\", num_request\": " << stats.num_request
        << ", \"bytes_read\": " << stats.bytes_read
-       << ", \"bytes_write\": " << stats.bytes_write
-       << ", \"duration\": " << stats.duration << "}";
+       << ", \"bytes_write\": " << stats.bytes_write << ", \"duration\": "
+       << std::chrono::duration<double>(stats.duration).count() << "}";
     return os;
 }
 
@@ -32,7 +32,11 @@ int run(int port, request_handler handler)
 {
     asio::io_context ctx;
 
-    async_run(ctx.get_executor(), port, handler);
+    async_run(
+        ctx.get_executor(), port,
+        [handler](request req) -> asio::awaitable<response> {
+            co_return handler(std::move(req));
+        });
 
     ctx.run();
 

--- a/test/test_session.cpp
+++ b/test/test_session.cpp
@@ -123,13 +123,14 @@ TEST_CASE("session", "[session]")
     const std::string body = test::make_random_string<std::string>(1024);
 
     int handler_called = 0;
-    auto handler = [&body, &handler_called](usrv::request req) {
+    auto handler = [&body, &handler_called](
+                       usrv::request req) -> asio::awaitable<usrv::response> {
         ++handler_called;
 
         usrv::response res(http::status::ok, req.version());
         res.body() = body;
 
-        return res;
+        co_return res;
     };
 
     auto future = co_spawn(


### PR DESCRIPTION
- Allow for async I/O inside a handler
- Allow for sync API calls or other blocking tasks inside a handler that are executed in a thread pool or other context