### PR TITLE
Improve test coverage, sanitizer, and tidy builds.

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,9 @@
 add_executable(usrv-example example.cpp)
 target_link_libraries(usrv-example PRIVATE httpmicroservice::httpmicroservice)
 
+add_executable(usrv-threadpool threadpool.cpp)
+target_link_libraries(usrv-threadpool PRIVATE httpmicroservice::httpmicroservice)
+
 add_executable(usrv-basic basic.cpp)
 target_link_libraries(usrv-basic PRIVATE httpmicroservice::httpmicroservice)
 

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -11,17 +11,13 @@ namespace asio = boost::asio;
 namespace usrv = httpmicroservice;
 namespace http = httpmicroservice::http;
 
-usrv::response handler(usrv::request req)
+asio::awaitable<usrv::response> handler(usrv::request req)
 {
     usrv::response res(http::status::ok, req.version());
     res.set(http::field::content_type, "application/json");
     res.body() = "{\"hello\": \"world\"}";
 
-    return res;
-}
-
-void reporter(const usrv::session_stats& stats)
-{
+    co_return res;
 }
 
 int main()
@@ -31,8 +27,7 @@ int main()
 
         auto ioc = asio::io_context{};
 
-        usrv::async_run(
-            ioc.get_executor(), port, handler, usrv::session_stats_reporter{});
+        usrv::async_run(ioc.get_executor(), port, handler, false);
 
         // SIGTERM is sent by Docker to ask us to stop (politely)
         // SIGINT handles local Ctrl+C in a terminal

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -27,6 +27,7 @@ int main()
 
         auto ioc = asio::io_context{};
 
+        // Single threaded. The request handler runs in the I/O thread.
         usrv::async_run(ioc.get_executor(), port, handler, false);
 
         // SIGTERM is sent by Docker to ask us to stop (politely)

--- a/examples/threadpool.cpp
+++ b/examples/threadpool.cpp
@@ -1,4 +1,5 @@
 #include <httpmicroservice.hpp>
+#include <httpmicroservice/format.hpp>
 #include <httpmicroservice/service.hpp>
 
 #include <boost/asio/signal_set.hpp>
@@ -21,6 +22,11 @@ asio::awaitable<usrv::response> handler(usrv::request req)
     co_return res;
 }
 
+void reporter(const usrv::session_stats& stats)
+{
+    fmt::print("{}\n", stats);
+}
+
 int main()
 {
     try {
@@ -33,7 +39,7 @@ int main()
 
         usrv::async_run(
             ioc.get_executor(), port, usrv::make_co_handler(ex, handler),
-            usrv::session_stats_reporter{});
+            false);
 
         // SIGTERM is sent by Docker to ask us to stop (politely)
         // SIGINT handles local Ctrl+C in a terminal

--- a/examples/threadpool.cpp
+++ b/examples/threadpool.cpp
@@ -34,12 +34,14 @@ int main()
 
         auto ioc = asio::io_context{};
 
-        asio::thread_pool pool(1);
+        asio::thread_pool pool{1};
         auto ex = pool.get_executor();
 
+        // 2 threads. One for the http server I/O and one for the request
+        // handler. Print session stats to stdout.
         usrv::async_run(
             ioc.get_executor(), port, usrv::make_co_handler(ex, handler),
-            false);
+            reporter);
 
         // SIGTERM is sent by Docker to ask us to stop (politely)
         // SIGINT handles local Ctrl+C in a terminal

--- a/include/httpmicroservice.hpp
+++ b/include/httpmicroservice.hpp
@@ -4,10 +4,8 @@
 
 namespace httpmicroservice {
 
-int run(int port, request_handler handler);
+response make_response(const request& req);
 
 int getenv_port();
-
-response make_response(const request& req);
 
 } // namespace httpmicroservice

--- a/include/httpmicroservice/format.hpp
+++ b/include/httpmicroservice/format.hpp
@@ -1,0 +1,24 @@
+#include <httpmicroservice/types.hpp>
+
+#include <fmt/core.h>
+
+template <>
+struct fmt::formatter<httpmicroservice::session_stats> {
+    constexpr auto parse(format_parse_context& ctx)
+    {
+        return ctx.begin();
+    }
+
+    template <typename FormatContext>
+    auto format(
+        const httpmicroservice::session_stats& stats, FormatContext& ctx) const
+    {
+        return fmt::format_to(
+            ctx.out(),
+            "{{\"fd\": {}, \"num_request\": {}, \"bytes_read\": {}, "
+            "\"bytes_write\": {}, \"duration\": {}}}",
+            stats.fd, stats.num_request, stats.bytes_read, stats.bytes_write,
+            std::chrono::duration<double>(stats.end_time - stats.start_time)
+                .count());
+    }
+};

--- a/include/httpmicroservice/session.hpp
+++ b/include/httpmicroservice/session.hpp
@@ -59,7 +59,7 @@ session(AsyncStream stream, Handler handler, std::optional<session_stats> stats)
             }
         }
 
-        const auto keep_alive = req.keep_alive();
+        const bool keep_alive = req.keep_alive();
 
         // res = handler(req)
         response res = co_await std::invoke(handler, std::move(req));

--- a/include/httpmicroservice/types.hpp
+++ b/include/httpmicroservice/types.hpp
@@ -28,6 +28,4 @@ struct session_stats {
     std::chrono::steady_clock::time_point end_time{};
 };
 
-using session_stats_reporter = std::function<void(const session_stats&)>;
-
 } // namespace httpmicroservice

--- a/include/httpmicroservice/types.hpp
+++ b/include/httpmicroservice/types.hpp
@@ -7,7 +7,6 @@
 
 #include <boost/beast/http/message.hpp>
 #include <boost/beast/http/string_body.hpp>
-#include <fmt/core.h>
 
 #include <chrono>
 #include <functional>
@@ -29,25 +28,6 @@ struct session_stats {
     std::chrono::steady_clock::time_point end_time{};
 };
 
+using session_stats_reporter = std::function<void(const session_stats&)>;
+
 } // namespace httpmicroservice
-
-template <>
-struct fmt::formatter<httpmicroservice::session_stats> {
-    constexpr auto parse(format_parse_context& ctx)
-    {
-        return ctx.begin();
-    }
-
-    template <typename FormatContext>
-    auto format(
-        const httpmicroservice::session_stats& stats, FormatContext& ctx) const
-    {
-        return fmt::format_to(
-            ctx.out(),
-            "{{\"fd\": {}, \"num_request\": {}, \"bytes_read\": {}, "
-            "\"bytes_write\": {}, \"duration\": {}}}",
-            stats.fd, stats.num_request, stats.bytes_read, stats.bytes_write,
-            std::chrono::duration<double>(stats.end_time - stats.start_time)
-                .count());
-    }
-};

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -2,6 +2,9 @@
 
 #include <httpmicroservice.hpp>
 
+#include <array>
+#include <cstdlib>
+
 namespace usrv = httpmicroservice;
 
 TEST_CASE("make_response", "[usrv]")
@@ -11,4 +14,36 @@ TEST_CASE("make_response", "[usrv]")
 
     REQUIRE(res.result_int() == 200);
     REQUIRE(req.version() == res.version());
+}
+
+TEST_CASE("getenv_port", "[usrv]")
+{
+    constexpr auto kName = "PORT";
+    REQUIRE(unsetenv(kName) == 0);
+
+    REQUIRE(usrv::getenv_port() == 8080);
+
+    for (int port=1024; port<=65535; ++port) {
+        const auto str = std::to_string(port);
+        REQUIRE(setenv(kName, str.c_str(), 1) == 0);
+    
+        REQUIRE(usrv::getenv_port() == port);
+    }
+
+    constexpr std::array<int, 6> kBadRange = {-10, 0, 80, 1023, 65536, 100000};
+
+    for (int port : kBadRange) {
+        const auto str = std::to_string(port);
+        REQUIRE(setenv(kName, str.c_str(), 1) == 0);
+
+        REQUIRE_THROWS(usrv::getenv_port());
+    }
+
+    constexpr std::array<const char*, 4> kBadNumber = {"-dingo", "3.14 is pi", ".8080.1234", "nope"};
+
+    for (auto str : kBadNumber) {
+        REQUIRE(setenv(kName, str, 1) == 0);
+
+        REQUIRE_THROWS(usrv::getenv_port());
+    }
 }

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -41,11 +41,22 @@ TEST_CASE("run_async")
         co_return res;
     };
 
+    auto reporter = [](const usrv::session_stats& stats) {
+        REQUIRE(stats.fd > 0);
+
+        if (stats.num_request > 0) {
+            REQUIRE(stats.bytes_read > 0);
+            REQUIRE(stats.bytes_write > 0);
+            REQUIRE(stats.end_time > stats.start_time);
+        }
+    };
+
     // Run server in its own thread so we can call ctx.stop() from main
     asio::io_context ctx;
     auto server =
         std::async(std::launch::async, [&ctx, awaitable_handler, reporter]() {
-            usrv::async_run(ctx.get_executor(), kPort, awaitable_handler);
+            usrv::async_run(
+                ctx.get_executor(), kPort, awaitable_handler, reporter);
 
             ctx.run_for(5s);
         });
@@ -58,7 +69,8 @@ TEST_CASE("run_async")
         asio::io_context ctx;
 
         tcp::resolver resolver(ctx);
-        auto endpoint = *resolver.resolve("127.0.0.1", std::to_string(kPort));
+        const tcp::endpoint endpoint =
+            *resolver.resolve("127.0.0.1", std::to_string(kPort));
 
         boost::system::error_code ec;
 

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -14,7 +14,7 @@
 #include <string>
 #include <thread>
 
-TEST_CASE("run_async")
+TEST_CASE("async_run", "[service]")
 {
     using namespace std::chrono_literals;
     namespace asio = boost::asio;
@@ -114,4 +114,22 @@ TEST_CASE("run_async")
 
     REQUIRE(server.wait_for(2s) == std::future_status::ready);
     REQUIRE_NOTHROW(server.get());
+}
+
+TEST_CASE("make_co_handler", "[service]")
+{
+    asio::io_context ctx;
+
+    auto awaitable_handler = [](auto req) -> asio::awaitable<usrv::response> {
+        co_return usrv::response{};
+    };
+
+    {
+        auto co_handler =
+            usrv::make_co_handler(ctx.get_executor(), awaitable_handler);
+    }
+
+    {
+        auto co_handler = usrv::make_co_handler(ctx, awaitable_handler);
+    }
 }

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -43,11 +43,12 @@ TEST_CASE("run_async")
 
     // Run server in its own thread so we can call ctx.stop() from main
     asio::io_context ctx;
-    auto server = std::async(std::launch::async, [&ctx, awaitable_handler]() {
-        usrv::async_run(ctx.get_executor(), kPort, awaitable_handler);
+    auto server =
+        std::async(std::launch::async, [&ctx, awaitable_handler, reporter]() {
+            usrv::async_run(ctx.get_executor(), kPort, awaitable_handler);
 
-        ctx.run_for(5s);
-    });
+            ctx.run_for(5s);
+        });
 
     usrv::request req(http::verb::get, "/", kHttpVersion);
 

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -118,18 +118,17 @@ TEST_CASE("async_run", "[service]")
 
 TEST_CASE("make_co_handler", "[service]")
 {
+    namespace asio = boost::asio;
+    namespace usrv = httpmicroservice;
+
     asio::io_context ctx;
 
     auto awaitable_handler = [](auto req) -> asio::awaitable<usrv::response> {
         co_return usrv::response{};
     };
 
-    {
-        auto co_handler =
-            usrv::make_co_handler(ctx.get_executor(), awaitable_handler);
-    }
+    auto co_handler =
+        usrv::make_co_handler(ctx.get_executor(), awaitable_handler);
 
-    {
-        auto co_handler = usrv::make_co_handler(ctx, awaitable_handler);
-    }
+    REQUIRE(ctx.run() == 0);
 }

--- a/tools/build_coverage.sh
+++ b/tools/build_coverage.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+export CC=clang-14
+export CXX=clang++-14
+
 conan profile new coverage --detect
 conan profile update settings.build_type=Debug coverage
 conan profile update settings.compiler=clang coverage
@@ -15,9 +18,9 @@ cmake -B . -S .. -GNinja \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
   -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake
 
-cmake --build . --config Debug
+cmake --build . --config Debug -j 8
 
 export LLVM_PROFILE_FILE=coverage.profraw
 ctest -C Debug
-llvm-profdata-14 merge -sparse test/coverage.profraw -o test/coverage.profdata
-llvm-cov-14 show ./test/httpmicroservice_test -instr-profile=test/coverage.profdata >coverage.txt
+llvm-profdata-14 merge -sparse tests/coverage.profraw -o tests/coverage.profdata
+llvm-cov-14 show ./tests/usrv-test -instr-profile=tests/coverage.profdata >coverage.txt

--- a/tools/build_sanitizer.sh
+++ b/tools/build_sanitizer.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+export CC=clang-14
+export CXX=clang++-14
+
 conan profile new sanitizer --detect
 conan profile update settings.build_type=Debug sanitizer
 conan profile update settings.compiler=clang sanitizer
@@ -7,13 +10,15 @@ conan profile update settings.compiler.version=14 sanitizer
 conan profile update settings.compiler.libcxx=libc++ sanitizer
 conan install .. --build=missing --profile=sanitizer
 
-cmake -B . -S .. -GNinja \
+cmake .. -GNinja \
   -DCMAKE_BUILD_TYPE=Debug \
   -DCMAKE_CXX_COMPILER=clang++-14 \
-  -DCMAKE_CXX_FLAGS="-fsanitize=address,thread,signed-integer-overflow,null" \
+  -DCMAKE_CXX_FLAGS="-fsanitize=address" \
   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
   -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake
 
-cmake --build . --config Debug
+# thread,signed-integer-overflow,null
 
-ctest
+cmake --build . --config Debug -j 8
+
+ctest -C Debug

--- a/tools/build_tidy.sh
+++ b/tools/build_tidy.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+export CC=clang-14
+export CXX=clang++-14
+
 conan profile new tidy --detect
 conan profile update settings.build_type=Release tidy
 conan profile update settings.compiler=clang tidy
@@ -7,7 +10,7 @@ conan profile update settings.compiler.version=14 tidy
 conan profile update settings.compiler.libcxx=libc++ tidy
 conan install .. --build=missing --profile=tidy
 
-cmake -B . -S .. -GNinja \
+cmake .. -GNinja \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_COMPILER=clang++-14 \
   -DCMAKE_CXX_CLANG_TIDY=clang-tidy-14 \
@@ -15,5 +18,4 @@ cmake -B . -S .. -GNinja \
   -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake \
   -DBUILD_TESTING=OFF
 
-cmake --build . --config Release
-
+cmake --build . --config Release -j 8


### PR DESCRIPTION
- Added threadpool example app
- Move the fmt for session_stats into format.hpp header file
- Added signal handlers to the example apps
- Added Reporter to the service interface so clients can register a callback for session_stats