### PR TITLE
Refactor actions

### DIFF
--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -24,12 +24,11 @@ jobs:
     - name: Install build tools
       run: >
         sudo apt-get update
-        && sudo apt-get install -y clang-14 ninja-build pip
+        && sudo apt-get install -y clang-14 ninja-build
 
     - name: Install package manager
       run: >
-        python3 -m ensurepip --upgrade
-        && python3 -m pip install conan
+        pip3 install conan --upgrade
         && conan profile new default --detect
         && conan profile update settings.build_type=Debug default
         && conan profile update settings.compiler.libcxx=libc++ default

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -26,11 +26,11 @@ jobs:
         sudo apt-get update
         && sudo apt-get install -y clang-14 ninja-build pip
 
-    - uses: luketokheim/get-conan@main
-
-    - name: Create build profile
+    - name: Install package manager
       run: >
-        conan profile new default --detect
+        python3 -m ensurepip --upgrade
+        && python3 -m pip install conan
+        && conan profile new default --detect
         && conan profile update settings.build_type=Debug default
         && conan profile update settings.compiler.libcxx=libc++ default
 

--- a/.github/workflows/sanitizer.yaml
+++ b/.github/workflows/sanitizer.yaml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Install package manager
       run: >
-        pip3 install conan --upgrade
+        pipx install conan
         && conan profile new default --detect
         && conan profile update settings.build_type=Debug default
         && conan profile update settings.compiler.libcxx=libc++ default

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,15 +46,12 @@ jobs:
       #   settings.compiler.version=11
       #   settings.compiler.libcxx=libstdc++
       #
-      run: >
-        python3 -m ensurepip --upgrade
-        && python3 -m pip install conan
-        && conan profile new default --detect
+      run: pip3 install conan --upgrade
 
     - name: Install dependencies
       #
       # Download packages listed in our manifest. Generate toolchain file for
-      # CMake so that we can use find_package(...) to find deps
+      # CMake so that we can use find_package(...) to find deps.
       #
       run: >
         install -d build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,9 +46,7 @@ jobs:
       #   settings.compiler.version=11
       #   settings.compiler.libcxx=libstdc++
       #
-      run: >
-        pip3 install setuptools wheel --upgrade
-        && pip3 install conan --upgrade
+      run: pipx install conan
 
     - name: Install dependencies
       #

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,9 @@ jobs:
       #   settings.compiler.version=11
       #   settings.compiler.libcxx=libstdc++
       #
-      run: pip3 install conan --upgrade
+      run: >
+        pip3 install setuptools wheel --upgrade
+        && pip3 install conan --upgrade
 
     - name: Install dependencies
       #

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,13 +18,38 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
+      
       matrix:
         os: [windows-2022, macos-12, ubuntu-22.04]
 
     steps:
     - uses: actions/checkout@v3
 
-    - uses: luketokheim/get-conan@main
+    - name: Install package manager
+      #
+      # Install conan and autodetect the build profile. Defaults are:
+      #
+      # settings.build_type=Release
+      #
+      # - Windows Server 2022
+      #   settings.compiler=Visual Studio
+      #   settings.compiler.version=17
+      #
+      # - macOS 12.6
+      #   settings.compiler=apple-clang
+      #   settings.compiler.version=14
+      #   settings.compiler.libcxx=libc++
+      #
+      # - Ubuntu 22.04
+      #   settings.compiler=gcc
+      #   settings.compiler.version=11
+      #   settings.compiler.libcxx=libstdc++
+      #
+      run: >
+        python3 -m ensurepip --upgrade
+        && python3 -m pip install conan
+        && conan profile new default --detect
 
     - name: Install dependencies
       #

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,7 +46,9 @@ jobs:
       #   settings.compiler.version=11
       #   settings.compiler.libcxx=libstdc++
       #
-      run: pipx install conan
+      run: >
+        pipx install conan
+        && conan profile new default --detect
 
     - name: Install dependencies
       #
@@ -73,7 +75,7 @@ jobs:
       # Build all enabled programs with the current configuration.
       #
       working-directory: build
-      run: cmake --build .
+      run: cmake --build . --config=Release
 
     - name: Test
       #
@@ -85,4 +87,4 @@ jobs:
       #   add_test(UnitTestName unit_test)
       #
       working-directory: build
-      run: ctest --output-on-failure
+      run: ctest --output-on-failure --config=Release

--- a/.github/workflows/tidy.yaml
+++ b/.github/workflows/tidy.yaml
@@ -20,13 +20,13 @@ jobs:
     - name: Install build tools
       run: >
         sudo apt-get update
-        && sudo apt-get install -y clang-14 ninja-build pip
-    
-    - uses: luketokheim/get-conan@main
+        && sudo apt-get install -y clang-14 ninja-build
 
-    - name: Create build profile
+    - name: Install package manager
       run: >
-        conan profile new default --detect
+        python3 -m ensurepip --upgrade
+        && python3 -m pip install conan
+        && conan profile new default --detect
         && conan profile update settings.compiler.libcxx=libc++ default
 
     - name: Install dependencies

--- a/.github/workflows/tidy.yaml
+++ b/.github/workflows/tidy.yaml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Install package manager
       run: >
-        pip3 install conan --upgrade
+        pipx install conan
         && conan profile new default --detect
         && conan profile update settings.compiler.libcxx=libc++ default
 

--- a/.github/workflows/tidy.yaml
+++ b/.github/workflows/tidy.yaml
@@ -24,8 +24,7 @@ jobs:
 
     - name: Install package manager
       run: >
-        python3 -m ensurepip --upgrade
-        && python3 -m pip install conan
+        pip3 install conan --upgrade
         && conan profile new default --detect
         && conan profile update settings.compiler.libcxx=libc++ default
 


### PR DESCRIPTION
- Use ensurepip to install pip instead of the package manager or relying on the system
- Set fail-fast to false to allow all platforms to run
- Add notes for the conan profile defaults