### PR TITLE
Improvements for many connections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,13 @@ add_library(httpmicroservice::httpmicroservice ALIAS httpmicroservice)
 target_compile_features(httpmicroservice PUBLIC cxx_std_20)
 target_include_directories(httpmicroservice PUBLIC include)
 
-# BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT
+# Set default construction of asio::io_context for single thread
 target_compile_definitions(
     httpmicroservice
     PUBLIC
     BOOST_ASIO_NO_DEPRECATED
-    BOOST_ASIO_DISABLE_THREADS)
+    BOOST_ASIO_CONCURRENCY_HINT_DEFAULT=1
+    BOOST_ASIO_CONCURRENCY_HINT_1=BOOST_ASIO_CONCURRENCY_HINT_UNSAFE)
 
 # g++-10 or newer on Linux
 if(CMAKE_COMPILER_IS_GNUCXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,14 +9,6 @@ add_library(httpmicroservice::httpmicroservice ALIAS httpmicroservice)
 target_compile_features(httpmicroservice PUBLIC cxx_std_20)
 target_include_directories(httpmicroservice PUBLIC include)
 
-# Set default construction of asio::io_context for single thread
-target_compile_definitions(
-    httpmicroservice
-    PUBLIC
-    BOOST_ASIO_NO_DEPRECATED
-    BOOST_ASIO_CONCURRENCY_HINT_DEFAULT=1
-    BOOST_ASIO_CONCURRENCY_HINT_1=BOOST_ASIO_CONCURRENCY_HINT_UNSAFE)
-
 # g++-10 or newer on Linux
 if(CMAKE_COMPILER_IS_GNUCXX)
     find_package(Threads)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,13 @@ add_library(httpmicroservice::httpmicroservice ALIAS httpmicroservice)
 target_compile_features(httpmicroservice PUBLIC cxx_std_20)
 target_include_directories(httpmicroservice PUBLIC include)
 
+# BOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT
+target_compile_definitions(
+    httpmicroservice
+    PUBLIC
+    BOOST_ASIO_NO_DEPRECATED
+    BOOST_ASIO_DISABLE_THREADS)
+
 # g++-10 or newer on Linux
 if(CMAKE_COMPILER_IS_GNUCXX)
     find_package(Threads)

--- a/README.md
+++ b/README.md
@@ -32,21 +32,18 @@ namespace usrv = httpmicroservice;
 
 int main()
 {
-      asio::io_context ioc;
+    // Listen on port 8080 and route all HTTP requests to the hello_world handler
+    usrv::run(8080, hello_world);
 
-      // Listen on port 8080 and route all HTTP requests to the hello_world handler
-      usrv::async_run(ioc, 8080, hello_world);
-
-      // Run event processing loop
-      ioc.run();
-
-      return 0;
+    return 0;
 }
 ```
 
 Asio has excellent docs. Refer to those for more details on
-[io_context](https://think-async.com/Asio/asio-1.24.0/doc/asio/overview/basics.html)
-and [awaitable](https://think-async.com/Asio/asio-1.24.0/doc/asio/overview/composition/cpp20_coroutines.html).
+[Basic Asio Anatomy](https://think-async.com/Asio/asio-1.24.0/doc/asio/overview/basics.html)
+and [C++20 Coroutines Support](https://think-async.com/Asio/asio-1.24.0/doc/asio/overview/composition/cpp20_coroutines.html).
+
+## Docker
 
 Build a Docker image that runs the [Hello World](examples/hello.cpp) web service.
 
@@ -54,12 +51,15 @@ Build a Docker image that runs the [Hello World](examples/hello.cpp) web service
 docker build -t httpmicroservice-cpp .
 ```
 
+Run the container.
+
 ```console
 docker run --rm -p 8080:8080 httpmicroservice-cpp
 ```
 
 The image is based on the empty Docker "scratch" image and only contains the
-single binary [Hello World](examples/hello.cpp) example server.
+single binary [Hello World](examples/hello.cpp) example server. The image
+requires the io_uring kernel interface.
 
 ## Design
 
@@ -82,6 +82,28 @@ features that I omitted.
 - No request or keep alive timeouts
 - No request target resource to handler mapping
 - No static content or nice error pages
+
+## Async
+
+The server uses only asynchronous operations. If you have used Asio before then
+this main function will look more familiar.
+
+```cpp
+int main()
+{
+    asio::io_context ioc;
+
+    // Listen on port 8080 and route all HTTP requests to the hello_world handler
+    usrv::async_run(ioc, 8080, hello_world);
+
+    // Run event processing loop
+    ioc.run();
+
+    return 0;
+}
+```
+
+Most of my usage is with a single thread calling io_context::run().
 
 ## Requirements
 

--- a/include/httpmicroservice/service.hpp
+++ b/include/httpmicroservice/service.hpp
@@ -36,12 +36,8 @@ accept(Acceptor acceptor, Handler handler, Reporter reporter)
     for (;;) {
         auto [ec, stream] = co_await acceptor.async_accept();
 
-        if (ec == asio::error::no_descriptors) {
-            continue;
-        }
-
         if (ec) {
-            break;
+            continue;
         }
 
         stream.set_option(tcp::no_delay{true}, ec);

--- a/include/httpmicroservice/service.hpp
+++ b/include/httpmicroservice/service.hpp
@@ -36,7 +36,7 @@ accept(Acceptor acceptor, Handler handler, Reporter reporter)
     for (;;) {
         auto [ec, stream] = co_await acceptor.async_accept();
 
-        if (ec == boost::system::errc::too_many_files_open) {
+        if (ec == asio::error::no_descriptors) {
             continue;
         }
 

--- a/include/httpmicroservice/service.hpp
+++ b/include/httpmicroservice/service.hpp
@@ -38,6 +38,10 @@ accept(Acceptor acceptor, Handler handler, Reporter reporter)
         auto stream = co_await acceptor.async_accept(
             asio::redirect_error(asio::use_awaitable, ec));
 
+        if (ec == boost::system::errc::too_many_files_open) {
+            continue;
+        }
+
         if (ec) {
             break;
         }

--- a/include/httpmicroservice/session.hpp
+++ b/include/httpmicroservice/session.hpp
@@ -6,6 +6,7 @@
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/beast/http/read.hpp>
 #include <boost/beast/http/write.hpp>
+#include <fmt/core.h>
 
 #include <chrono>
 #include <type_traits>
@@ -65,6 +66,10 @@ session(AsyncStream stream, Handler handler, Reporter reporter)
             }
 
             if (ec) {
+                if (ec != asio::error::connection_reset &&
+                    ec != asio::error::connection_aborted) {
+                    fmt::print("async_read = {} {}\n", ec.value(), ec.message());
+                }
                 break;
             }
 
@@ -84,6 +89,10 @@ session(AsyncStream stream, Handler handler, Reporter reporter)
         auto [ec, bytes_write] = co_await http::async_write(stream, res);
 
         if (ec) {
+            if (ec != asio::error::connection_reset &&
+                ec != asio::error::connection_aborted) {
+                fmt::print("async_write = {} {}\n", ec.value(), ec.message());
+            }
             break;
         }
 

--- a/include/httpmicroservice/session.hpp
+++ b/include/httpmicroservice/session.hpp
@@ -6,7 +6,6 @@
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/beast/http/read.hpp>
 #include <boost/beast/http/write.hpp>
-#include <fmt/core.h>
 
 #include <chrono>
 #include <type_traits>
@@ -66,10 +65,6 @@ session(AsyncStream stream, Handler handler, Reporter reporter)
             }
 
             if (ec) {
-                if (ec != asio::error::connection_reset &&
-                    ec != asio::error::connection_aborted) {
-                    fmt::print("async_read = {} {}\n", ec.value(), ec.message());
-                }
                 break;
             }
 
@@ -89,10 +84,6 @@ session(AsyncStream stream, Handler handler, Reporter reporter)
         auto [ec, bytes_write] = co_await http::async_write(stream, res);
 
         if (ec) {
-            if (ec != asio::error::connection_reset &&
-                ec != asio::error::connection_aborted) {
-                fmt::print("async_write = {} {}\n", ec.value(), ec.message());
-            }
             break;
         }
 

--- a/tests/mock_sock.hpp
+++ b/tests/mock_sock.hpp
@@ -10,17 +10,23 @@ namespace test {
   Model the AsyncStream type concept for Boost beast and asio. Allow us to test
   the session(...) loop with random input data and verify the roundtrip.
 
-  https://www.boost.org/doc/libs/1_80_0/doc/html/boost_asio/reference/AsyncReadStream.html
-  https://www.boost.org/doc/libs/1_80_0/doc/html/boost_asio/reference/AsyncWriteStream.html
+  https://www.boost.org/doc/libs/release/doc/html/boost_asio/reference/AsyncReadStream.html
+  https://www.boost.org/doc/libs/release/doc/html/boost_asio/reference/AsyncWriteStream.html
  */
-template <typename Buffer>
+template <typename Buffer, typename Executor>
 class mock_sock {
 public:
-    using executor_type = boost::asio::io_context::executor_type;
+    using executor_type = Executor;
+
+    // Need this to specialize default completion handlers for as_tuple_t, etc.
+    template <typename Executor1>
+    struct rebind_executor {
+        typedef mock_sock<Buffer, Executor1> other;
+    };
 
     enum shutdown_type { shutdown_receive, shutdown_send, shutdown_both };
 
-    mock_sock(executor_type ex)
+    explicit mock_sock(executor_type ex)
         : ex_{ex}, rx_{std::make_shared<Buffer>()},
           tx_{std::make_shared<Buffer>()}
     {

--- a/tests/test_service.cpp
+++ b/tests/test_service.cpp
@@ -68,9 +68,9 @@ TEST_CASE("async_run", "[service]")
     auto client = std::async(std::launch::async, [req]() {
         asio::io_context ioc;
 
-        tcp::resolver resolver(ioc);
-        const tcp::endpoint endpoint =
-            *resolver.resolve("127.0.0.1", std::to_string(kPort));
+        const tcp::endpoint endpoint{
+            asio::ip::make_address("127.0.0.1"),
+            static_cast<asio::ip::port_type>(kPort)};
 
         boost::system::error_code ec;
 
@@ -219,8 +219,9 @@ TEST_CASE("integration", "[service]")
     auto client_partial_write = [&num_client]() -> asio::awaitable<void> {
         // Send partial request and close socket
         {
-            tcp::endpoint endpoint(
-                asio::ip::address_v4::from_string("127.0.0.1"), kPort);
+            const tcp::endpoint endpoint{
+                asio::ip::make_address("127.0.0.1"),
+                static_cast<asio::ip::port_type>(kPort)};
 
             tcp::socket socket{co_await asio::this_coro::executor};
 
@@ -251,8 +252,9 @@ TEST_CASE("integration", "[service]")
     auto client_partial_read = [&num_client]() -> asio::awaitable<void> {
         // Send complete request, do partial read
         {
-            tcp::endpoint endpoint(
-                asio::ip::address_v4::from_string("127.0.0.1"), kPort);
+            const tcp::endpoint endpoint{
+                asio::ip::make_address("127.0.0.1"),
+                static_cast<asio::ip::port_type>(kPort)};
 
             tcp::socket socket{co_await asio::this_coro::executor};
 


### PR DESCRIPTION
- Do not break out of the accept loop if we run out of files, keep trying
- Use default completion token internally, always awaitable, always return a tuple with the error_code rather than throw exception
- Tested io_context{1} and io_context{BOOST_ASIO_CONCURRENCY_HINT_UNSAFE} with wrk